### PR TITLE
fix(web): mobile home screen width

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
           className="animate-in fade-in slide-in-from-bottom-1 absolute -z-10 size-full"
           style={{ color: "transparent", animationDuration: "10s" }}
         />
-        <main className="h-full">{children}</main>
+        {children}
       </body>
       <GoogleAnalytics gaId="G-STY9BKWKT4" />
     </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -27,8 +27,8 @@ const infoCardContent = [
 
 export default function Page(): JSX.Element {
   return (
-    <main className="container flex h-full flex-col">
-      <section className="flex w-full flex-col lg:flex-row-reverse">
+    <main className="flex flex-col">
+      <section className="flex w-full flex-col lg:container lg:flex-row-reverse">
         <div className="z-10 mt-16 flex w-full flex-col justify-center p-10 lg:w-1/2">
           <h2
             className="text-slate-6 w-full text-center text-[3rem] leading-10">
@@ -44,7 +44,7 @@ export default function Page(): JSX.Element {
             </Link>
           </div>
         </div>
-        <div className="flex w-full justify-center lg:w-1/2">
+        <div className="flex w-full justify-center overflow-hidden lg:w-1/2">
           <video
             className="-z-20 w-full max-w-2xl"
             style={{
@@ -60,7 +60,9 @@ export default function Page(): JSX.Element {
           ></video>
         </div>
       </section>
-      <section style={{boxShadow: "0px -20px 44px -60px rgb(255 255 255)"}} className="border-slate-6 relative mt-20 flex max-w-5xl flex-col items-center rounded-3xl border-t px-6 py-12 sm:py-24 md:max-w-7xl">
+      <section
+        style={{boxShadow: "0px -20px 44px -60px rgb(255 255 255)"}}
+        className="border-slate-6 relative mt-10 flex flex-col items-center overflow-hidden rounded-3xl border-t px-6 py-12 lg:container sm:mx-5 sm:py-24 md:mx-10">
         <div
           aria-hidden="true"
           className="center pointer-events-none absolute -top-1 left-1/2 -z-20 h-[200px] w-full max-w-[200px] -translate-x-1/2 -translate-y-1/2 md:max-w-[400px]"

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 export const Header = () => {
   return (
-    <nav className="container z-10 flex justify-between p-5 px-10">
+    <nav className="container z-10 flex justify-between p-5">
       <Link href="/">
         <h1 className="text-base font-semibold text-white">
           Bolhadev.chat


### PR DESCRIPTION
Currently there is a horizontal scroll on home screen due the video not being correct cropped

![bolhadev chat_](https://github.com/brunocroh/bolhadev.chat/assets/15933/5f232adb-31ae-41cf-b90d-c1ece93d8557)

With some changes I could manage it

![localhost_3000_](https://github.com/brunocroh/bolhadev.chat/assets/15933/8a273ae6-bef6-46d3-9bb0-dcaf3c06bc89)

There were a double `<main>` element, I removed it.

_Theres a lot of classes that doesnt make sense to me, I hate taildwild_

This is related to #7 but It does not address all